### PR TITLE
Add meta charset for replace ascii with UTF-8

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta charset="UTF-8">
     <style>
       body {
         width: 200px;


### PR DESCRIPTION
I saw your code for in `popup.html`. it has no charset setting in meta tag. in the future, it'll make you extension break in some client. please coding carefully,

I'll tell you some story.

```
The "meta" is info in the head. charset = character set utf-8 is character
encoding capable of encoding all characters on the web. It replaced ascii as
the default character encoding. Because it is the default all modern browsers
will use utf-8 without being explicitly told to do so. It remains in meta data
as a common good practice. Until the powers that be (unicode consortium)
decide not to use it. utf-8 is used for something like 93% of all web traffic.
That's long story

for Short one: leave it in.
```

Topic from https://teamtreehouse.com/community/meta-charsetutf8-what-does-this-mean-or-what-does-it-do-i-deleted-it-from-the-code-and-nothing-changed