### PR TITLE
Add lang-en attribute in html tag

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="UTF-8">
     <style>


### PR DESCRIPTION
I suggest you set "en" as the primary language for a document.

The lang attribute takes an ISO language code as its value. Typically this is a two-letter code such as “en” for English.

The lang attribute must also be used to identify chunks of text in a language that is different from the document’s primary language.

Source from: https://developer.paciellogroup.com/blog/2016/06/using-the-html-lang-attribute/